### PR TITLE
fixes for group / permission

### DIFF
--- a/nixos/modules/services/networking/cato-client.nix
+++ b/nixos/modules/services/networking/cato-client.nix
@@ -16,15 +16,8 @@ in
   };
 
   config = mkIf cfg.enable {
-    #users.users = {
-    #  cato-client = {
-    #    isSystemUser = true;
-    #    group = "cato-client";
-    #    description = "Cato Client daemon user";
-    #  };
-    #};
-    users.groups = {
-      cato-client = { };
+    users = {
+      groups.cato-client = { };
     };
 
     systemd.services.cato-client = {
@@ -34,8 +27,7 @@ in
 
       serviceConfig = {
         Type = "simple";
-        #User = "cato-client";
-        User = "root";
+        User = "root"; # Note: daemon runs as root, tools sticky to group
         Group = "cato-client";
         ExecStart = "${cfg.package}/bin/cato-clientd systemd";
         WorkingDirectory = "${cfg.package}";
@@ -43,6 +35,23 @@ in
       };
 
       wantedBy = [ "multi-user.target" ];
+    };
+
+    # set up Security wrapper Same as inteded in deb post install
+    security.wrappers.cato-clientd = {
+      source = "${cfg.package}/bin/cato-clientd";
+      owner = "root";
+      group = "cato-client";
+      permissions = "u+rwx,g+rwx"; # 770
+      setgid = true;
+    };
+
+    security.wrappers.cato-sdp = {
+      source = "${cfg.package}/bin/cato-sdp";
+      owner = "root";
+      group = "cato-client";
+      permissions = "u+rwx,g+rx,a+rx"; # 755
+      setgid = true;
     };
   };
 }

--- a/nixos/modules/services/networking/cato-client.nix
+++ b/nixos/modules/services/networking/cato-client.nix
@@ -20,6 +20,10 @@ in
       groups.cato-client = { };
     };
 
+    environment.systemPackages = [
+      cfg.package
+    ];
+
     systemd.services.cato-client = {
       enable = true;
       description = "Cato Networks Linux client - connects tunnel to Cato cloud";


### PR DESCRIPTION
With those changes i was able to:

1. Add second nixpkgs as flake input
```
    cato-vpn-nixpkgs = {
      # url = "github:YarekTyshchenko/nixpkgs/init-cato";
      url = "github:DxCx/nixpkgs/init-cato";
    };
```
2. import module / package from my nixos flake:
```
  imports = [
    "${flake.inputs.cato-vpn-nixpkgs}/nixos/modules/services/networking/cato-client.nix"
  ];

  services = {
    # Available because of the import above
    cato-client = {
      enable = true;
      package =
        pkgs.callPackage "${flake.inputs.cato-vpn-nixpkgs}/pkgs/by-name/ca/cato-client/package.nix"
          { };
    };
  };
```
3. add my user to `cato-client` group:
```
  users.users.<name> = {
     extraGroups = [ "cato-client" ];
  };
```
4. After reboot (to apply group add to current user) use `cato-sdp` from cli (and browser open for login screen)
5. verified authentication works and also that connection works post authentication